### PR TITLE
docs: update MCP OAuth setup guide

### DIFF
--- a/content/docs/cli_docs/index.mdx
+++ b/content/docs/cli_docs/index.mdx
@@ -39,8 +39,8 @@ SOKOSUMI_API_URL=https://app.sokosumi.com
 ```
 
 **Getting your Sokosumi API Key:**
-1. Go to [https://app.sokosumi.com/account](https://app.sokosumi.com/account)
-2. Scroll down to the **API Keys** section
+1. Go to [https://app.sokosumi.com/connections](https://app.sokosumi.com/connections)
+2. Open the **API Keys** tab
 3. Create a new API key and copy it to your `.env` file
 
 ### 4. Run the CLI

--- a/content/docs/documentation/index.mdx
+++ b/content/docs/documentation/index.mdx
@@ -115,7 +115,7 @@ Both notices link directly to the billing tab appropriate for your plan.
 <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mt-6">
   <div className="border rounded-lg p-4">
     <h4 className="font-semibold mb-2">🚀 Quick Start</h4>
-    <p className="text-sm mb-3">Connect Claude to Sokosumi agents in under a minute</p>
+    <p className="text-sm mb-3">Connect an MCP client to Sokosumi agents in under a minute</p>
     <a href="/mcp" className="text-primary hover:underline">MCP Setup Guide →</a>
   </div>
   

--- a/content/docs/mcp/index.mdx
+++ b/content/docs/mcp/index.mdx
@@ -10,14 +10,15 @@ Three setup methods. Pick one.
 
 ---
 
-## Method 1: Quick Link (Recommended)
+## Method 1: Hosted MCP Connection (Recommended)
 
-Generate a connection URL directly from your Sokosumi account and paste it into Claude Desktop. No local server, no config files.
+Connect Claude to the hosted Sokosumi MCP server. The hosted server uses OAuth, so Claude opens a browser and asks you to sign in with Sokosumi during setup. No API key needs to be copied into Claude.
 
-1. Go to [app.sokosumi.com](https://app.sokosumi.com) → your profile menu → **MCP**
-2. Click **Generate Your Sokosumi MCP URL** and copy the link
+1. Go to [app.sokosumi.com/connections](https://app.sokosumi.com/connections) → **MCP**
+2. Copy the MCP server URL: `https://mcp.sokosumi.com/mcp`
 3. Open Claude Desktop → **Settings** → **Connectors** → **Custom Connector**
 4. Paste the URL and click **Connect**
+5. Complete the Sokosumi OAuth sign-in when Claude opens the browser
 
 That's it. The Sokosumi tools are live in Claude Desktop.
 
@@ -169,10 +170,10 @@ This creates symlinks in `.claude/skills`. Use these only where you want project
 ## Troubleshooting
 
 **Can't connect?**
-1. Re-copy the full MCP link from your profile — it includes your API key
-2. Verify the key is active in [Account Settings](https://app.sokosumi.com/account)
+1. Use the hosted MCP URL: `https://mcp.sokosumi.com/mcp`
+2. Complete the Sokosumi OAuth sign-in in the browser window Claude opens
 3. Disconnect and reconnect in Claude Desktop
-4. Check you're using the correct network (`mainnet` vs `preprod`)
+4. For local development only, verify `SOKOSUMI_API_KEY` and `SOKOSUMI_NETWORK`
 
 **Job submitted — how long do I wait?**  
 Most jobs complete within 1–5 minutes. Ask Claude to check the status, or use `/sokosumi:watch <job_id>` to get notified automatically.

--- a/content/docs/mcp/index.mdx
+++ b/content/docs/mcp/index.mdx
@@ -1,10 +1,10 @@
 ---
 title: MCP Setup Guide
-description: Connect Claude to Sokosumi agents via MCP — quick link, local dev, and Claude Code plugin (v1.3.0).
+description: Connect MCP-capable clients such as Claude Desktop, Claude Code, or Codex to Sokosumi agents — hosted OAuth, local dev, and Claude Code plugin setup.
 icon: Network
 ---
 
-The Sokosumi MCP server gives Claude access to every agent on the marketplace. Ask Claude to find agents, submit jobs, check results, manage tasks, and monitor coworkers — all through natural language.
+The Sokosumi MCP server gives MCP-capable clients access to every agent on the marketplace. Use Claude Desktop, Claude Code, Codex, or another MCP client to find agents, submit jobs, check results, manage tasks, and monitor coworkers — all through natural language.
 
 Three setup methods. Pick one.
 
@@ -12,15 +12,15 @@ Three setup methods. Pick one.
 
 ## Method 1: Hosted MCP Connection (Recommended)
 
-Connect Claude to the hosted Sokosumi MCP server. The hosted server uses OAuth, so Claude opens a browser and asks you to sign in with Sokosumi during setup. No API key needs to be copied into Claude.
+Connect your MCP client to the hosted Sokosumi MCP server. The hosted server uses OAuth, so your client opens a browser and asks you to sign in with Sokosumi during setup. No API key needs to be copied into the client.
 
 1. Go to [app.sokosumi.com/connections](https://app.sokosumi.com/connections) → **MCP**
 2. Copy the MCP server URL: `https://mcp.sokosumi.com/mcp`
-3. Open Claude Desktop → **Settings** → **Connectors** → **Custom Connector**
+3. Open your MCP client, for example Claude Desktop → **Settings** → **Connectors** → **Custom Connector**
 4. Paste the URL and click **Connect**
-5. Complete the Sokosumi OAuth sign-in when Claude opens the browser
+5. Complete the Sokosumi OAuth sign-in when your client opens the browser
 
-That's it. The Sokosumi tools are live in Claude Desktop.
+That's it. The Sokosumi tools are live in your MCP client.
 
 <Callout type="tip">
 Once connected, try: *"Show me all available AI agents on Sokosumi"* or *"Create a job using agent X with these parameters..."*
@@ -51,7 +51,7 @@ SOKOSUMI_NETWORK=mainnet   # or "preprod"
 
 Get your API key at [app.sokosumi.com/account](https://app.sokosumi.com/account) → API Keys.
 
-Then add to your Claude Desktop MCP config:
+Then add the server to your MCP client config. For Claude Desktop, use:
 
 **macOS:** `~/Library/Application Support/Claude/claude_desktop_config.json`  
 **Windows:** `%APPDATA%\Claude\claude_desktop_config.json`
@@ -71,7 +71,7 @@ Then add to your Claude Desktop MCP config:
 }
 ```
 
-Restart Claude Desktop after saving.
+Restart your MCP client after saving.
 
 <Callout type="info">
 Local mode is for development. For production use, Method 1 (quick link) is recommended.
@@ -103,7 +103,7 @@ The Sokosumi MCP ships as a **Claude Code plugin** (`sokosumi`) with pre-built s
 
 ### Background Task Monitor (v1.3.0)
 
-**Hannah and Elena automatically start a background monitor for every task they create.** When a long-running task finishes or needs your input, it reports back on its own — no manual status checks.
+**Hannah, Elena, research, market, and direct agent workflows automatically start a background monitor for long-running tasks or jobs they create.** When work finishes or needs your input, it reports back on its own — no manual status checks.
 
 You can also arm the monitor yourself:
 
@@ -171,9 +171,9 @@ This creates symlinks in `.claude/skills`. Use these only where you want project
 
 **Can't connect?**
 1. Use the hosted MCP URL: `https://mcp.sokosumi.com/mcp`
-2. Complete the Sokosumi OAuth sign-in in the browser window Claude opens
-3. Disconnect and reconnect in Claude Desktop
+2. Complete the Sokosumi OAuth sign-in in the browser window your client opens
+3. Disconnect and reconnect the MCP server in your client
 4. For local development only, verify `SOKOSUMI_API_KEY` and `SOKOSUMI_NETWORK`
 
 **Job submitted — how long do I wait?**  
-Most jobs complete within 1–5 minutes. Ask Claude to check the status, or use `/sokosumi:watch <job_id>` to get notified automatically.
+Most jobs complete within 1–5 minutes. Ask your MCP client to check the status, or use `/sokosumi:watch <job_id>` in Claude Code to get notified automatically.


### PR DESCRIPTION
## Summary
- Update MCP setup docs to use the hosted OAuth MCP endpoint
- Remove stale generated API-key link troubleshooting from the hosted setup path

## Verification
- Documentation-only change; reviewed rendered MDX source